### PR TITLE
Start end mow session

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <targetSelectedWithDropDown>
+    <runningDeviceTargetSelectedWithDropDown>
       <Target>
-        <type value="QUICK_BOOT_TARGET" />
+        <type value="RUNNING_DEVICE_TARGET" />
         <deviceKey>
           <Key>
-            <type value="VIRTUAL_DEVICE_PATH" />
-            <value value="C:\Users\Lasse\.android\avd\Pixel_XL_API_33.avd" />
+            <type value="SERIAL_NUMBER" />
+            <value value="R3CRB0HFJ6Z" />
           </Key>
         </deviceKey>
       </Target>
-    </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2023-05-03T09:24:24.439234Z" />
+    </runningDeviceTargetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-05-04T11:49:06.065662700Z" />
   </component>
 </project>

--- a/app/src/main/java/se/ju/student/robomow/ui/MainActivity.kt
+++ b/app/src/main/java/se/ju/student/robomow/ui/MainActivity.kt
@@ -62,6 +62,24 @@ class MainActivity : AppCompatActivity() {
                 startActivity(it)
             }
         }
+
+        val startSessionButton = findViewById<Button>(R.id.start_session_button)
+        startSessionButton.setOnClickListener {
+            if (bluetoothClient == null) {
+                Toast.makeText(this, "Connect to a mower to start its session", Toast.LENGTH_SHORT).show()
+            } else {
+                bluetoothClient!!.sendMessage("START_SESSION")
+            }
+        }
+
+        val endSessionButton = findViewById<Button>(R.id.end_session_button)
+        endSessionButton.setOnClickListener {
+            if (bluetoothClient == null) {
+                Toast.makeText(this, "Connect to a mower to end its session", Toast.LENGTH_SHORT).show()
+            } else {
+                bluetoothClient!!.sendMessage("END_SESSION")
+            }
+        }
     }
 
     private fun requestPermission() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,6 +26,7 @@
         android:layout_height="50dp"
         android:text="Routes" />
 
+    <!-- for creating a gap between the buttons -->
     <View
         android:layout_width="match_parent"
         android:layout_height="32dp" />
@@ -36,7 +37,7 @@
         android:orientation="horizontal">
 
         <Button
-            android:id="@+id/start_session"
+            android:id="@+id/start_session_button"
             android:backgroundTint="@color/success_green"
             android:layout_width="170dp"
             android:layout_height="50dp"
@@ -44,7 +45,7 @@
             android:text="Start session" />
 
         <Button
-            android:id="@+id/end_session"
+            android:id="@+id/end_session_button"
             android:backgroundTint="@color/warning_red"
             android:layout_width="170dp"
             android:layout_height="50dp"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -26,4 +26,29 @@
         android:layout_height="50dp"
         android:text="Routes" />
 
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="32dp" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/start_session"
+            android:backgroundTint="@color/success_green"
+            android:layout_width="170dp"
+            android:layout_height="50dp"
+            android:layout_marginEnd="16dp"
+            android:text="Start session" />
+
+        <Button
+            android:id="@+id/end_session"
+            android:backgroundTint="@color/warning_red"
+            android:layout_width="170dp"
+            android:layout_height="50dp"
+            android:layout_marginStart="16dp"
+            android:text="End session" />
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,55 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
-    android:orientation="vertical"
     tools:context=".ui.MainActivity">
 
     <Button
         android:id="@+id/connect_button"
-        android:layout_width="150dp"
+        android:layout_width="wrap_content"
         android:layout_height="50dp"
-        android:text="@string/connect" />
+        android:text="@string/connect"
+        android:minWidth="150dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/control_button"
+        app:layout_constraintVertical_chainStyle="packed" />
 
     <Button
         android:id="@+id/control_button"
-        android:layout_width="150dp"
+        android:layout_width="wrap_content"
         android:layout_height="50dp"
-        android:text="Control" />
+        android:text="Control"
+        android:minWidth="150dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/connect_button"
+        app:layout_constraintBottom_toTopOf="@+id/route_button" />
 
     <Button
         android:id="@+id/route_button"
-        android:layout_width="150dp"
-        android:layout_height="50dp"
-        android:text="Routes" />
-
-    <!-- for creating a gap between the buttons -->
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="32dp" />
-
-    <LinearLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:layout_height="50dp"
+        android:text="Routes"
+        android:minWidth="150dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/control_button"
+        app:layout_constraintBottom_toTopOf="@+id/start_session_button" />
 
-        <Button
-            android:id="@+id/start_session_button"
-            android:backgroundTint="@color/success_green"
-            android:layout_width="170dp"
-            android:layout_height="50dp"
-            android:layout_marginEnd="16dp"
-            android:text="Start session" />
+    <Button
+        android:id="@+id/start_session_button"
+        android:backgroundTint="@color/success_green"
+        android:layout_marginTop="20dp"
+        android:layout_width="wrap_content"
+        android:layout_height="50dp"
+        android:text="Start session"
+        app:layout_constraintEnd_toStartOf="@+id/end_session_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/route_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintHorizontal_chainStyle="packed"
+        android:layout_marginEnd="8dp"
+        android:minWidth="150dp"/>
 
-        <Button
-            android:id="@+id/end_session_button"
-            android:backgroundTint="@color/warning_red"
-            android:layout_width="170dp"
-            android:layout_height="50dp"
-            android:layout_marginStart="16dp"
-            android:text="End session" />
-    </LinearLayout>
-</LinearLayout>
+    <Button
+        android:id="@+id/end_session_button"
+        android:backgroundTint="@color/warning_red"
+        android:layout_width="wrap_content"
+        android:layout_height="50dp"
+        android:layout_marginTop="20dp"
+        android:text="End session"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/start_session_button"
+        app:layout_constraintTop_toBottomOf="@+id/route_button"
+        android:layout_marginStart="8dp"
+        android:minWidth="150dp"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -11,4 +11,6 @@
     <color name="white">#FFFFFFFF</color>
     <color name="off_white">#F5F5F5</color>
     <color name="red">#FFFF0000</color>
+    <color name="warning_red">#d0342c</color>
+    <color name="success_green">#4BB543</color>
 </resources>


### PR DESCRIPTION
Mow sessions can now be started and ended from the main activity.
Main activity layout is using a constraint layout now so that it looks as intended on all screen sizes

If the user has not connected to a mower before clicking, a toast is displayed instead.
![Screenshot_20230504_135031_RoboMow](https://user-images.githubusercontent.com/89852390/236195796-5e57eb54-3945-43de-a045-f682ceb0a44c.jpg)

(Currently, there is no logic for checking if there already is an active session)