### PR TITLE
Feature highlight active mow session

### DIFF
--- a/app/src/main/java/se/ju/student/robomow/adapter/MowSessionAdapter.kt
+++ b/app/src/main/java/se/ju/student/robomow/adapter/MowSessionAdapter.kt
@@ -46,7 +46,7 @@ class MowSessionAdapter(
     }
 
     fun updateData(newData: List<MowSession>) {
-        mowSessions = newData
+        mowSessions = newData.sortedWith(compareBy({ !mowSessionIsComplete(it) }, { it.start.seconds })).reversed()
         notifyDataSetChanged()
     }
 

--- a/app/src/main/java/se/ju/student/robomow/adapter/MowSessionAdapter.kt
+++ b/app/src/main/java/se/ju/student/robomow/adapter/MowSessionAdapter.kt
@@ -1,10 +1,12 @@
 package se.ju.student.robomow.adapter
 
 import android.content.Context
+import android.graphics.drawable.ColorDrawable
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import se.ju.student.robomow.R
 import se.ju.student.robomow.model.MowSession
@@ -20,7 +22,7 @@ class MowSessionAdapter(
 ) : RecyclerView.Adapter<MowSessionAdapter.MowSessionViewHolder>() {
     class MowSessionViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val date: TextView = itemView.findViewById(R.id.mow_session_date)
-        val status: TextView = itemView.findViewById(R.id.mow_session_status)
+        val status: View = itemView.findViewById(R.id.mow_session_status_indicator)
         val collisions: TextView = itemView.findViewById(R.id.mow_session_collisions)
         val mowingTime: TextView = itemView.findViewById(R.id.mow_session_mowing_time)
     }
@@ -34,13 +36,13 @@ class MowSessionAdapter(
     override fun onBindViewHolder(holder: MowSessionViewHolder, position: Int) {
         val mowSession = mowSessions[position]
         holder.date.text = getDateTimeFromTimeStamp(mowSession.start.seconds)
-        holder.status.text = getMowingStatus(mowSession)
         holder.collisions.text = context.getString(
             R.string.avoided_collisions,
             mowSession.avoidedCollisions.size
         )
         holder.itemView.setOnClickListener { onItemClicked(mowSession) }
         holder.mowingTime.text = getMowingTime(mowSession)
+        holder.status.background = ColorDrawable(getStatusIndicatorColor(mowSession))
     }
 
     fun updateData(newData: List<MowSession>) {
@@ -48,15 +50,16 @@ class MowSessionAdapter(
         notifyDataSetChanged()
     }
 
-    private fun getMowingStatus(mowSession: MowSession): String {
-        if (mowSessionIsComplete(mowSession)) {
-            return context.getString(R.string.mowing_status_complete)
-        }
-        return context.getString(R.string.mowing_status_active)
-    }
-
     private fun mowSessionIsComplete(mowSession: MowSession): Boolean {
         return mowSession.end != null
+    }
+
+    private fun getStatusIndicatorColor(mowSession: MowSession): Int{
+        return if (mowSessionIsComplete(mowSession)) {
+            ContextCompat.getColor(context, R.color.completed_session_indicator_color)
+        } else {
+            ContextCompat.getColor(context, R.color.success_green)
+        }
     }
 
     private fun convertToHoursMinutes(startTimeStamp: Long, endTimeStamp: Long): Pair<Int, Int> {

--- a/app/src/main/res/layout/mow_session_item.xml
+++ b/app/src/main/res/layout/mow_session_item.xml
@@ -1,14 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/mow_session_container"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="8dp">
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Mow Session" />
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <View
+            android:id="@+id/mow_session_status_indicator"
+            android:layout_width="12dp"
+            android:layout_height="12dp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="8dp"
+            android:background="#9e9e9e"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Mow Session" />
+
+    </LinearLayout>
 
     <TextView
         android:id="@+id/mow_session_date"

--- a/app/src/main/res/layout/mow_session_item.xml
+++ b/app/src/main/res/layout/mow_session_item.xml
@@ -34,13 +34,6 @@
         android:textStyle="bold"
         android:text="date"/>
 
-
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/mow_session_status"
-        android:text="@string/mowing_status_complete"/>
-
     <TextView
         android:id="@+id/mow_session_mowing_time"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,5 +12,6 @@
     <color name="off_white">#F5F5F5</color>
     <color name="red">#FFFF0000</color>
     <color name="warning_red">#d0342c</color>
+    <color name="completed_session_indicator_color">#9E9E9E</color>
     <color name="success_green">#4BB543</color>
 </resources>


### PR DESCRIPTION
Mow session status is now indicated with a View element on the list item 
green is for active sessions & grey is for completed sessions

The active mow session is always the first list item in the recycler view. The rest of the items are ordered by start date (newest to oldest).

![status indicator](https://user-images.githubusercontent.com/89852390/236822049-6c7c3e57-3eed-4aa3-9a1f-e34a5b704c88.png)