### PR TITLE
Feature avoided collision name on route

### DIFF
--- a/app/src/main/java/se/ju/student/robomow/data/CollisionAvoidanceCircle.kt
+++ b/app/src/main/java/se/ju/student/robomow/data/CollisionAvoidanceCircle.kt
@@ -3,5 +3,6 @@ package se.ju.student.robomow.data
 data class CollisionAvoidanceCircle(
     val x: Float,
     val y: Float,
-    val radius:Float = 20f
+    val avoidedObject: String,
+    val radius:Float = 25f
 )

--- a/app/src/main/java/se/ju/student/robomow/data/CollisionAvoidanceCircle.kt
+++ b/app/src/main/java/se/ju/student/robomow/data/CollisionAvoidanceCircle.kt
@@ -3,5 +3,5 @@ package se.ju.student.robomow.data
 data class CollisionAvoidanceCircle(
     val x: Float,
     val y: Float,
-    val radius:Float = 10f
+    val radius:Float = 20f
 )

--- a/app/src/main/java/se/ju/student/robomow/ui/constants/MapConstants.kt
+++ b/app/src/main/java/se/ju/student/robomow/ui/constants/MapConstants.kt
@@ -42,7 +42,7 @@ object MapConstants {
     }
     val collisionPaint = Paint().apply {
         color = Color.RED
-        style = Paint.Style.STROKE
+        style = Paint.Style.FILL_AND_STROKE
         strokeWidth = BORDER_STROKE_WIDTH
     }
 }

--- a/app/src/main/java/se/ju/student/robomow/ui/constants/MapConstants.kt
+++ b/app/src/main/java/se/ju/student/robomow/ui/constants/MapConstants.kt
@@ -8,6 +8,7 @@ object MapConstants {
     const val BORDER_COLOR = 0xFF09A104.toInt()
     const val START_POSITION_COLOR = Color.BLUE
     const val START_POSITION_TEXT_COLOR = Color.WHITE
+    const val AVOIDED_COLLISION_TEXT_COLOR = Color.WHITE
     const val TEXT_SIZE = 18f
     const val PATH_STROKE_WIDTH = 15f
     const val BORDER_STROKE_WIDTH = 20f
@@ -40,6 +41,13 @@ object MapConstants {
         textSize = TEXT_SIZE
         textAlign = Paint.Align.CENTER
     }
+
+    val collisionTextPaint = Paint().apply {
+        color = AVOIDED_COLLISION_TEXT_COLOR
+        textSize = TEXT_SIZE
+        textAlign = Paint.Align.CENTER
+    }
+
     val collisionPaint = Paint().apply {
         color = Color.RED
         style = Paint.Style.FILL_AND_STROKE

--- a/app/src/main/java/se/ju/student/robomow/ui/view/MapView.kt
+++ b/app/src/main/java/se/ju/student/robomow/ui/view/MapView.kt
@@ -184,7 +184,8 @@ class MapView(context: Context, attrs: AttributeSet) : View(context, attrs) {
                     Pair(
                         CollisionAvoidanceCircle(
                             canvasX,
-                            canvasY
+                            canvasY,
+                            avoidedCollision.avoidedObject
                         ), avoidedCollision
                     )
                 )

--- a/app/src/main/java/se/ju/student/robomow/ui/view/ZoomableMapView.kt
+++ b/app/src/main/java/se/ju/student/robomow/ui/view/ZoomableMapView.kt
@@ -260,7 +260,7 @@ class ZoomableMapView(context: Context, attrs: AttributeSet?) : View(context, at
         y: Float,
         collisionAvoidanceCircle: CollisionAvoidanceCircle
     ): Boolean {
-        val circlePadding = 30
+        val circlePadding = 50
         return (x >= collisionAvoidanceCircle.x - circlePadding
                 && x <= collisionAvoidanceCircle.x + circlePadding
                 && y >= collisionAvoidanceCircle.y - circlePadding

--- a/app/src/main/java/se/ju/student/robomow/ui/view/ZoomableMapView.kt
+++ b/app/src/main/java/se/ju/student/robomow/ui/view/ZoomableMapView.kt
@@ -14,7 +14,9 @@ import se.ju.student.robomow.model.AvoidedCollisions
 import se.ju.student.robomow.model.Position
 import se.ju.student.robomow.ui.constants.MapConstants
 import se.ju.student.robomow.ui.constants.MapConstants.collisionPaint
+import se.ju.student.robomow.ui.constants.MapConstants.collisionTextPaint
 import se.ju.student.robomow.ui.constants.MapConstants.mowerImagePaint
+import se.ju.student.robomow.ui.constants.MapConstants.startTextPaint
 import se.ju.student.robomow.ui.view.utils.MapUtils
 import kotlin.math.min
 import kotlin.math.max
@@ -108,6 +110,17 @@ class ZoomableMapView(context: Context, attrs: AttributeSet?) : View(context, at
         canvas.drawPath(path, MapConstants.pathPaint)
         collisionAvoidanceCircleAndAvoidedCollisions.forEach {
             canvas.drawCircle(it.first.x, it.first.y, it.first.radius, collisionPaint)
+            var text = it.first.avoidedObject
+
+            if (text.length > 6) {
+                val line1 = text.substring(0, 6)
+                val line2 = if (text.length > 11) text.substring(6, 11) + ".." else text.substring(6)
+
+                canvas.drawText(line1, it.first.x, it.first.y - it.first.radius/3, collisionTextPaint)
+                canvas.drawText(line2, it.first.x, it.first.y + it.first.radius/3 + (collisionTextPaint.textSize / 3), collisionTextPaint)
+            } else {
+                canvas.drawText(text, it.first.x, it.first.y + (collisionTextPaint.textSize / 3), collisionTextPaint)
+            }
         }
 
         // Draw the start position
@@ -247,7 +260,8 @@ class ZoomableMapView(context: Context, attrs: AttributeSet?) : View(context, at
                     Pair(
                         CollisionAvoidanceCircle(
                             canvasX,
-                            canvasY
+                            canvasY,
+                            avoidedCollision.avoidedObject
                         ), avoidedCollision
                     )
                 )
@@ -260,7 +274,7 @@ class ZoomableMapView(context: Context, attrs: AttributeSet?) : View(context, at
         y: Float,
         collisionAvoidanceCircle: CollisionAvoidanceCircle
     ): Boolean {
-        val circlePadding = 50
+        val circlePadding = 55
         return (x >= collisionAvoidanceCircle.x - circlePadding
                 && x <= collisionAvoidanceCircle.x + circlePadding
                 && y >= collisionAvoidanceCircle.y - circlePadding

--- a/app/src/main/java/se/ju/student/robomow/ui/view/ZoomableMapView.kt
+++ b/app/src/main/java/se/ju/student/robomow/ui/view/ZoomableMapView.kt
@@ -116,8 +116,8 @@ class ZoomableMapView(context: Context, attrs: AttributeSet?) : View(context, at
                 val line1 = text.substring(0, 6)
                 val line2 = if (text.length > 11) text.substring(6, 11) + ".." else text.substring(6)
 
-                canvas.drawText(line1, it.first.x, it.first.y - it.first.radius/3, collisionTextPaint)
-                canvas.drawText(line2, it.first.x, it.first.y + it.first.radius/3 + (collisionTextPaint.textSize / 3), collisionTextPaint)
+                canvas.drawText(line1, it.first.x, it.first.y - it.first.radius/2.5f + (collisionTextPaint.textSize / 3), collisionTextPaint)
+                canvas.drawText(line2, it.first.x, it.first.y + it.first.radius/2.5f + (collisionTextPaint.textSize / 3), collisionTextPaint)
             } else {
                 canvas.drawText(text, it.first.x, it.first.y + (collisionTextPaint.textSize / 3), collisionTextPaint)
             }


### PR DESCRIPTION
CollisionAvoidanceCircle now contains the avoided object as a string.
The circle is now larger, this means that up to 11 characters fit among two lines. In the case of the string being longer than 11 characters, it is cut short with `..`
If you think it would look better, we could keep it to one line with fewer characters.

If string size <= 6:
<img width="187" alt="collision text" src="https://github.com/IMS-mower-group-1/mower-mobile-app/assets/89852390/77b10a7a-0672-474c-b8f6-381cf7c7e004">

If string size is between 7-11:
<img width="234" alt="collision two line text" src="https://github.com/IMS-mower-group-1/mower-mobile-app/assets/89852390/f9b8ed2b-46ec-4d38-97d8-558435ab72f1">

If string size > 11:
<img width="337" alt="collision cut text" src="https://github.com/IMS-mower-group-1/mower-mobile-app/assets/89852390/cd998af8-ec33-48d3-b661-97f6c0c93677">

